### PR TITLE
Add the vsext file to the solution Items folder

### DIFF
--- a/src/ExtensionManager.Shared/Commands/ExportSolutionCommand.cs
+++ b/src/ExtensionManager.Shared/Commands/ExportSolutionCommand.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Windows.Forms;
 using EnvDTE;
+using EnvDTE80;
 using ExtensionManager.Importer;
 using Microsoft;
 using Microsoft.VisualStudio.Shell;
@@ -60,7 +61,7 @@ namespace ExtensionManager
 
             try
             {
-                var extensions = _es.GetInstalledExtensions().ToList(); 
+                var extensions = _es.GetInstalledExtensions().ToList();
 
                 if (File.Exists(fileName))
                 {
@@ -88,6 +89,11 @@ namespace ExtensionManager
                     string json = JsonConvert.SerializeObject(manifest, Formatting.Indented);
 
                     File.WriteAllText(fileName, json);
+
+                    // Add the file to the solution items folder if it's new or if it's not there already.
+                    var solItems = GetOrCreateSolutionItems((DTE2)dte);
+                    solItems.ProjectItems.AddFromFile(fileName);
+
                     VsShellUtilities.OpenDocument(ServiceProvider, fileName);
                 }
             }
@@ -129,6 +135,26 @@ namespace ExtensionManager
             }
 
             return false;
+        }
+
+        /// <summary>
+        /// Gets or creates solution items folder (project).
+        /// from https://blog.agchapman.com/creating-solution-items-from-vs-extension/
+        /// </summary>
+        /// <param name="dte">The DTE.</param>
+        /// <returns>the solution items folder (project)</returns>
+        static Project GetOrCreateSolutionItems(DTE2 dte)
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
+            var solItems = dte.Solution.Projects.Cast<Project>().FirstOrDefault(p => p.Name == "Solution Items" || p.Kind == EnvDTE.Constants.vsProjectItemKindSolutionItems);
+            if (solItems == null)
+            {
+                Solution2 sol2 = (Solution2)dte.Solution;
+                solItems = sol2.AddSolutionFolder("Solution Items");
+                dte.StatusBar.Text = $"Created Solution Items project for solution {dte.Solution.FullName}";
+            }
+            return solItems;
         }
     }
 }


### PR DESCRIPTION
Having dangling file outside the solution can be an issue with source controls like TFS that relies on the solution for operations like "Get Latest". Having the file in the solution makes it easier to work with it.