### PR TITLE
Created FilePathHelpers to avoid code duplication

### DIFF
--- a/src/ExtensionManager.Shared/Commands/ExportCommand.cs
+++ b/src/ExtensionManager.Shared/Commands/ExportCommand.cs
@@ -2,9 +2,9 @@
 using System.Collections.Generic;
 using System.ComponentModel.Design;
 using System.IO;
-using System.Windows.Forms;
 using Microsoft.VisualStudio.Shell;
 using Newtonsoft.Json;
+using static ExtensionManager.FilePathHelpers;
 
 namespace ExtensionManager
 {
@@ -70,28 +70,6 @@ namespace ExtensionManager
                     Microsoft.VisualStudio.Shell.Interop.OLEMSGDEFBUTTON.OLEMSGDEFBUTTON_FIRST
                 );
             }
-        }
-
-        private bool TryGetFilePath(out string filePath)
-        {
-            filePath = null;
-
-            using (var sfd = new SaveFileDialog())
-            {
-                sfd.DefaultExt = ".vsext";
-                sfd.FileName = "extensions";
-                sfd.Filter = "VSEXT File|*.vsext";
-
-                DialogResult result = sfd.ShowDialog();
-
-                if (result == DialogResult.OK)
-                {
-                    filePath = sfd.FileName;
-                    return true;
-                }
-            }
-
-            return false;
         }
     }
 }

--- a/src/ExtensionManager.Shared/Commands/ExportSolutionCommand.cs
+++ b/src/ExtensionManager.Shared/Commands/ExportSolutionCommand.cs
@@ -2,7 +2,6 @@
 using System.ComponentModel.Design;
 using System.IO;
 using System.Linq;
-using System.Windows.Forms;
 using EnvDTE;
 using ExtensionManager.Importer;
 using Microsoft;
@@ -60,7 +59,7 @@ namespace ExtensionManager
 
             try
             {
-                var extensions = _es.GetInstalledExtensions().ToList(); 
+                var extensions = _es.GetInstalledExtensions().ToList();
 
                 if (File.Exists(fileName))
                 {
@@ -107,28 +106,6 @@ namespace ExtensionManager
                     OLEMSGBUTTON.OLEMSGBUTTON_OK,
                     OLEMSGDEFBUTTON.OLEMSGDEFBUTTON_FIRST
                 );
-        }
-
-        private bool TryGetFilePath(out string filePath)
-        {
-            filePath = null;
-
-            using (var sfd = new SaveFileDialog())
-            {
-                sfd.DefaultExt = ".vsext";
-                sfd.FileName = "extensions";
-                sfd.Filter = "VSEXT File|*.vsext";
-
-                DialogResult result = sfd.ShowDialog();
-
-                if (result == DialogResult.OK)
-                {
-                    filePath = sfd.FileName;
-                    return true;
-                }
-            }
-
-            return false;
         }
     }
 }

--- a/src/ExtensionManager.Shared/Commands/ImportCommand.cs
+++ b/src/ExtensionManager.Shared/Commands/ImportCommand.cs
@@ -5,7 +5,6 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Net;
-using System.Windows.Forms;
 using EnvDTE;
 using ExtensionManager.Importer;
 using Microsoft;
@@ -15,6 +14,7 @@ using Microsoft.VisualStudio.Setup.Configuration;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using Task = System.Threading.Tasks.Task;
+using static ExtensionManager.FilePathHelpers;
 
 namespace ExtensionManager
 {
@@ -142,28 +142,6 @@ namespace ExtensionManager
             }
 
             await Task.WhenAll(tasks);
-        }
-
-        private bool TryGetFilePath(out string filePath)
-        {
-            filePath = null;
-
-            using (var sfd = new OpenFileDialog())
-            {
-                sfd.DefaultExt = ".vsext";
-                sfd.FileName = "extensions";
-                sfd.Filter = "VSEXT File|*.vsext";
-
-                DialogResult result = sfd.ShowDialog();
-
-                if (result == DialogResult.OK)
-                {
-                    filePath = sfd.FileName;
-                    return true;
-                }
-            }
-
-            return false;
         }
 
         public static bool HasRootSuffix(out string rootSuffix)

--- a/src/ExtensionManager.Shared/ExtensionManager.Shared.projitems
+++ b/src/ExtensionManager.Shared/ExtensionManager.Shared.projitems
@@ -14,6 +14,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Commands\ImportCommand.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Commands\SolutionPrompter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ExtensionService.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Helpers\FilePathHelpers.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Importer\ImportWindow.xaml.cs">
       <DependentUpon>ImportWindow.xaml</DependentUpon>
     </Compile>

--- a/src/ExtensionManager.Shared/Helpers/FilePathHelpers.cs
+++ b/src/ExtensionManager.Shared/Helpers/FilePathHelpers.cs
@@ -1,0 +1,29 @@
+﻿using System.Windows.Forms;
+
+namespace ExtensionManager
+{
+    public static class FilePathHelpers
+    {
+        public static bool TryGetFilePath(out string filePath)
+        {
+            filePath = null;
+
+            using (var sfd = new SaveFileDialog())
+            {
+                sfd.DefaultExt = ".vsext";
+                sfd.FileName = "extensions";
+                sfd.Filter = "VSEXT File|*.vsext";
+
+                DialogResult result = sfd.ShowDialog();
+
+                if (result == DialogResult.OK)
+                {
+                    filePath = sfd.FileName;
+                    return true;
+                }
+            }
+
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
The method TryGetFilePath was duplicated in the different commands. Code has been centralized in a dedicated helper class.