### PR TITLE
Remove Select All, Deselect All buttons in favor of a single cb

### DIFF
--- a/src/ExtensionManager.Shared/Importer/ImportWindow.xaml
+++ b/src/ExtensionManager.Shared/Importer/ImportWindow.xaml
@@ -33,8 +33,8 @@
 
         <StackPanel Grid.Row="4" Orientation="Horizontal" HorizontalAlignment="Right">
             <UniformGrid HorizontalAlignment="Right" Rows="1" Columns="2">
-                <Button Content="Select" Name="btnOk" IsDefault="true" Click="Button_Click" Margin="10 0 0 0"/>
-                <Button Content="Cancel" IsCancel="true" Margin="10 0 0 0"/>
+                <Button Content="OK" Name="btnOk" IsDefault="true" Click="Button_Click" Margin="10 0 0 0" Width="75" Height="23" />
+                <Button Content="Cancel" IsCancel="true" Margin="10 0 0 0" Width="75" Height="23" />
             </UniformGrid>
         </StackPanel>
     </Grid>

--- a/src/ExtensionManager.Shared/Importer/ImportWindow.xaml
+++ b/src/ExtensionManager.Shared/Importer/ImportWindow.xaml
@@ -10,6 +10,7 @@
     <Grid Margin="10 10 10 10">
         <Grid.RowDefinitions>
             <RowDefinition Height="auto" />
+            <RowDefinition Height="auto" />
             <RowDefinition Height="*" />
             <RowDefinition Height="auto" />
             <RowDefinition Height="auto" />
@@ -20,19 +21,19 @@
                 <AccessText TextWrapping="Wrap" Text="Only extensions published to the Visual Studio Marketplace are shown."/>
             </Label.Content>
         </Label>
-        <Border Grid.Row="1" Margin="0 0 0 10" BorderThickness="1" BorderBrush="DarkGray">
+        <CheckBox Grid.Row="1" Name="chkSelectDeselectAll" Content="Select/deselect all" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="0 0 0 10"
+                  Checked="SelectDeselectAll_Checked" Unchecked="SelectDeselectAll_Unchecked"/>
+        <Border Grid.Row="2" Margin="0 0 0 10" BorderThickness="1" BorderBrush="DarkGray">
             <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Hidden">
                 <StackPanel Name="list" Orientation="Vertical" Margin="5,5,5,10"/>
             </ScrollViewer>
         </Border>
 
-        <CheckBox Grid.Row="2" Name="chkInstallSystemWide" Content="Install for all users" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="0 0 0 10"/>
+        <CheckBox Grid.Row="3" Name="chkInstallSystemWide" Content="Install for all users" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="0 0 0 10"/>
 
-        <StackPanel Grid.Row="3" Orientation="Horizontal" HorizontalAlignment="Right">
-            <UniformGrid HorizontalAlignment="Right" Rows="1" Columns="4">
+        <StackPanel Grid.Row="4" Orientation="Horizontal" HorizontalAlignment="Right">
+            <UniformGrid HorizontalAlignment="Right" Rows="1" Columns="2">
                 <Button Content="Select" Name="btnOk" IsDefault="true" Click="Button_Click" Margin="10 0 0 0"/>
-                <Button Content="Select All" Name="btnSelectAll" Click="SelectAllButton_Click" Margin="10 0 0 0" />
-                <Button Content="Deselect All" Name="btnDeselectAll" Click="DeselectAllButton_Click" Margin="10 0 0 0"/>
                 <Button Content="Cancel" IsCancel="true" Margin="10 0 0 0"/>
             </UniformGrid>
         </StackPanel>

--- a/src/ExtensionManager.Shared/Importer/ImportWindow.xaml.cs
+++ b/src/ExtensionManager.Shared/Importer/ImportWindow.xaml.cs
@@ -142,6 +142,25 @@ namespace ExtensionManager.Importer
 
             return dialog;
         }
+
+        private void SelectDeselectAll_Checked(object sender, RoutedEventArgs e)
+        {
+            SelectDeselectAll();
+        }
+
+        private void SelectDeselectAll_Unchecked(object sender, RoutedEventArgs e)
+        {
+            SelectDeselectAll();
+        }
+
+        private void SelectDeselectAll()
+        {
+            if (!list.Children.OfType<CheckBox>().Any())
+                return;
+
+            foreach(var cb in list.Children.OfType<CheckBox>())
+                cb.IsChecked = chkSelectDeselectAll.IsChecked;
+        }
     }
 
     public enum Purpose


### PR DESCRIPTION
Removed the **Select All** and **Deselect All** buttons added by @JkeFos in favor of just a single **Select/deselect all** check box that appears above the list.  I think this UI/UX is much cleaner, and as a Desktop UI/UX expert, I believe it is also more consistent with other Desktop user interfaces for similar patterns.