### PR TITLE
Fixed #35.

### DIFF
--- a/src/ExtensionManager.Shared/Importer/ImportWindow.xaml.cs
+++ b/src/ExtensionManager.Shared/Importer/ImportWindow.xaml.cs
@@ -153,12 +153,26 @@ namespace ExtensionManager.Importer
             SelectDeselectAll();
         }
 
+        /// <summary>
+        /// Called to implement the functionality of the Select/Deselect All check box.
+        /// </summary>
         private void SelectDeselectAll()
         {
-            if (!list.Children.OfType<CheckBox>().Any())
+            // If check boxes are grayed out, always clear their check boxes
+            // since they are not applicable to the task at hand.
+            if (list.Children.OfType<CheckBox>().Any(cb=>!cb.IsEnabled))
+            {
+                foreach(var cb in list.Children.OfType<CheckBox>().Where(cb=>!cb.IsEnabled))
+                    cb.IsChecked = false;
+                return;
+            }
+
+            // Only let the Select/Deselect All check box work on those check boxes
+            // that aren't grayed out.
+            if (!list.Children.OfType<CheckBox>().Any(cb=>cb.IsEnabled))
                 return;
 
-            foreach(var cb in list.Children.OfType<CheckBox>())
+            foreach(var cb in list.Children.OfType<CheckBox>().Where(cb=>cb.IsEnabled))
                 cb.IsChecked = chkSelectDeselectAll.IsChecked;
         }
     }

--- a/src/ExtensionManager.Shared/Importer/ImportWindow.xaml.cs
+++ b/src/ExtensionManager.Shared/Importer/ImportWindow.xaml.cs
@@ -26,7 +26,7 @@ namespace ExtensionManager.Importer
                 lblMessage.Content = text;
             }
 
-            btnOk.Content = purpose == Purpose.Install ? "Install..." : "Select";
+            btnOk.Content = purpose == Purpose.Install ? "&Import" : "&Export";
             chkInstallSystemWide.Visibility = purpose == Purpose.Install ? Visibility.Visible : Visibility.Hidden;
         }
 


### PR DESCRIPTION
1. Updated docs.
2. First, the method starts asking if there are any disabled check boxes in the list.
   - If so, then it will forcibly clear the check marks in all such boxes, and then return.
    - Otherwise, it will only allow the Select/Deselect All checkbox to affect the states of only the enabled (i.e., grayed-in) check boxes.

This is necessary for two reasons:

1. In the "Import" modality of doing things, some extensions which might happen to be listed in the *.vsext file, might already be installed in Visual Studio.  Therefore, it is necessary to gray out their check boxes but still list them as already installed. It is not appropriate for the Select/Deselect All button to affect these check boxes, since they list extensions which are not relevant to the action being taken by the user (they are just listed for informational purposes only).

2. As the UI stands, a check mark in an extension's check box indicates that it is to be included in the collection of extensions that the current action (i.e., Import or Export) will affect.  Since grayed-out check boxes only show up for the Import side, and since the graying out means these extensions are already installed (and thus are not to be imported), it makes sense to me to force their check boxes to never have a check mark.  This way it is clear to the user that "these extensions aren't part of the Import action set."