### PR TITLE
Fixed #50 and #52

### DIFF
--- a/src/ExtensionManager.Shared/Models/Extension.cs
+++ b/src/ExtensionManager.Shared/Models/Extension.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.VisualStudio.ExtensionManager;
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 
 namespace ExtensionManager
 {

--- a/src/ExtensionManager.Shared/Models/Extension.cs
+++ b/src/ExtensionManager.Shared/Models/Extension.cs
@@ -25,11 +25,6 @@ namespace ExtensionManager
             return new Extension { ID = entry.VsixID, Name = entry.Name, MoreInfoUrl = entry.MoreInfoURL, DownloadUrl = entry.DownloadUrl };
         }
 
-        public static Extension FromIExtension(IExtension entry)
-        {
-            return new Extension { ID = entry.Header.Identifier, Name = entry.Header.Name, MoreInfoUrl = entry.Header.MoreInfoUrl?.ToString()};
-        }
-
         public override bool Equals(object obj)
         {
             return !(obj is Extension other) ? false : ID == other.ID;

--- a/src/ExtensionManager.Shared/Models/Extension.cs
+++ b/src/ExtensionManager.Shared/Models/Extension.cs
@@ -11,20 +11,23 @@ namespace ExtensionManager
         [JsonProperty("vsixId")]
         public string ID { get; set; }
 
-        [JsonIgnore]
+        [JsonProperty("moreInfoUrl")]
         public string MoreInfoUrl { get; set; }
+
+        [JsonProperty("downloadUrl")]
+        public string DownloadUrl { get; set; }
 
         [JsonIgnore]
         public bool Selected { get; set; }
 
         public static Extension FromGalleryExtension(GalleryEntry entry)
         {
-            return new Extension { ID = entry.VsixID, Name = entry.Name, MoreInfoUrl = entry.MoreInfoURL };
+            return new Extension { ID = entry.VsixID, Name = entry.Name, MoreInfoUrl = entry.MoreInfoURL, DownloadUrl = entry.DownloadUrl };
         }
 
         public static Extension FromIExtension(IExtension entry)
         {
-            return new Extension { ID = entry.Header.Identifier, Name = entry.Header.Name, MoreInfoUrl = entry.Header.MoreInfoUrl?.ToString() };
+            return new Extension { ID = entry.Header.Identifier, Name = entry.Header.Name, MoreInfoUrl = entry.Header.MoreInfoUrl?.ToString()};
         }
 
         public override bool Equals(object obj)


### PR DESCRIPTION
Added a `DownloadUrl` property to the `Extension` class in `Extension.cs` source file that lives in the `Models` folder of the `ExtensionManager.Shared` project. Added code to the `Extension.FromGalleryExtension` method in order to initialize the `DownloadUrl` property with the value of the entry's `DownloadUrl` property.

This is the new code for the `Extension.FromGalleryExtension` method:

```
public static Extension FromGalleryExtension(GalleryEntry entry)
{
	return new Extension 
	{ 
		ID = entry.VsixID,
		Name = entry.Name,
		MoreInfoUrl = entry.MoreInfoURL,
		DownloadUrl = entry.DownloadUrl 
	};
}
```
**Listing 1.** The new code for the `Extension.FromGalleryExtension` method.

**NOTE:** Listing 1 has been reformatted to add line breaks for easy readability in this GitHub comment.  The real code is all on one line in the `Extension.cs` file, as can be seen in this commit.

The new `DownloadUrl` property is declared thus:

```
// Extension.cs
using Microsoft.VisualStudio.ExtensionManager;
using Newtonsoft.Json;

namespace ExtensionManager
{
    public class Extension
    {
        /* ... */

        [JsonProperty("downloadUrl")]
        public string DownloadUrl { get; set; }

        /* ... */
    }
}
```
**Listing 2.** The declaration of the new `Extension.DownloadUrl` property.

Also, I changed the attribute decorating the `Extension.MoreInfoUrl` property from `JsonIgnore` to `JsonProperty` so that it gets output to the `.vsext` file as well.  This is a useful bit of information that scripts may want to parse.

```
// Extension.cs
using Microsoft.VisualStudio.ExtensionManager;
using Newtonsoft.Json;

namespace ExtensionManager
{
    public class Extension
    {
        /* ... */

        [JsonProperty("moreInfoUrl")]
        public string MoreInfoUrl{ get; set; }

        /* ... */
    }
}
```
**Listing 3.** New attribute for the `Extension.MoreInfoUrl` property.