### PR TITLE
Update link to Visual Studio Marketplace

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 [![Build status](https://ci.appveyor.com/api/projects/status/8p1hrumrxeh2hmks?svg=true)](https://ci.appveyor.com/project/loop8ack/extensionpacktools)
 
-Download the extension from the [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=MadsKristensen.ExtensionManager2022) or get the latest CI build: [VS 2017](http://vsixgallery.com/extension/e83d71b8-8bfc-4e06-b145-b0388910c016/), [VS 2019](http://vsixgallery.com/extension/4a196712-2c3f-4730-ad1d-e7cda4185eb2/), [VS 2022](http://vsixgallery.com/extension/4a196712-2c3f-4730-ad1d-e7cda4185eb3/)
+Download the extension from the [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=Loop8ack.ExtensionManager2022) or get the latest CI build: [VS 2017](http://vsixgallery.com/extension/e83d71b8-8bfc-4e06-b145-b0388910c016/), [VS 2019](http://vsixgallery.com/extension/4a196712-2c3f-4730-ad1d-e7cda4185eb2/), [VS 2022](http://vsixgallery.com/extension/4a196712-2c3f-4730-ad1d-e7cda4185eb3/)
 
 --------------------------------------
 


### PR DESCRIPTION
As the project was taken over the link also changed.

Fix #77